### PR TITLE
Better error support and shared actionTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,8 @@ export interface AsyncActionCreators<P, S, E> {
 }
 export interface ActionCreatorFactory {
     (type: string, commonMeta?: Object, error?: boolean): EmptyActionCreator;
-    <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
+    <P>(type: string, commonMeta?: Object, isError?: ((payload: P) => boolean) | boolean): ActionCreator<P>;
     async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, any>;
     async<P, S, E>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, E>;
 }
-export default function actionCreatorFactory(prefix?: string): ActionCreatorFactory;
+export default function actionCreatorFactory(prefix?: string, defaultIsError?: (payload: any) => boolean): ActionCreatorFactory;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,29 +3,47 @@ function isType(action, actionCreator) {
     return action.type === actionCreator.type;
 }
 exports.isType = isType;
-function actionCreatorFactory(prefix) {
+var isDev = (process && process.env && process.env.NODE_ENV) !== 'production';
+function wrapIsError(default_, isError) {
+    if (isError === undefined) {
+        return default_;
+    }
+    if (typeof isError === "boolean") {
+        return function () { return isError; };
+    }
+    return isError;
+}
+function actionCreatorFactory(prefix, defaultIsError) {
+    if (defaultIsError === void 0) { defaultIsError = function (p) { return p instanceof Error; }; }
     var actionTypes = {};
-    function actionCreator(type, commonMeta, error) {
-        if (actionTypes[type])
-            throw new Error("Duplicate action type: " + type);
-        actionTypes[type] = true;
-        var fullType = prefix ? prefix + "/" + type : type;
+    var base = prefix ? prefix + "/" : "";
+    function baseActionCreator(isError, type, commonMeta) {
+        var fullType = "" + base + type;
+        if (isDev) {
+            if (actionTypes[fullType])
+                throw new Error("Duplicate action type: " + fullType);
+            actionTypes[fullType] = true;
+        }
         return Object.assign(function (payload, meta) {
             var action = {
                 type: fullType,
                 payload: payload,
                 meta: Object.assign({}, commonMeta, meta),
             };
-            if (error)
-                action.error = error;
+            if (isError(payload)) {
+                action.error = true;
+            }
             return action;
         }, { type: fullType });
     }
+    var actionCreator = function (type, commonMeta, isError) {
+        return baseActionCreator(wrapIsError(defaultIsError, isError), type, commonMeta);
+    };
     function asyncActionCreators(type, commonMeta) {
         return {
             type: prefix ? prefix + "/" + type : type,
-            started: actionCreator(type + "_STARTED", commonMeta),
-            done: actionCreator(type + "_DONE", commonMeta),
+            started: actionCreator(type + "_STARTED", commonMeta, false),
+            done: actionCreator(type + "_DONE", commonMeta, false),
             failed: actionCreator(type + "_FAILED", commonMeta, true),
         };
     }


### PR DESCRIPTION
I really liked the spirit of the interface but found some things troubling. I have made quite a lot of small changes and would love to hear your feedback!
- Synchronous actions now accept P or Error. The error property is set based on (typeof payload), inspired by redux-actions.
- Asynchronous actions have type safe errors. The `complete` function can be used (if E extends Error) to automatically emit the done or failed action based on the payload type.
- payload is now P, rather than P | undefined
- actionTypes is shared between factories
- actionTypes is disabled if `process.env.NODE_ENV === 'production'`, saving a few bytes in production mode via dead code elimination.
