### PR TITLE
Make types a little more strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Created actions are FSA-compliant:
 ```ts
 interface Action<P> {
   type: string;
-  payload?: P;
+  payload: P;
   error?: boolean;
   meta?: Object;
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ const actionCreator = actionCreatorFactory();
 
 // specify parameters and result shapes as generic type arguments
 const doSomething = 
-  actionCreator.async<{foo: string}, {bar: number}>('DO_SOMETHING');
+  actionCreator.async<{foo: string},   // parameter type
+                      {bar: number},   // success type
+                      {code: number}   // error type
+                     >('DO_SOMETHING');
 
 console.log(doSomething.started({foo: 'lol'}));
 // {type: 'DO_SOMETHING_STARTED', payload: {foo: 'lol'}}

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,9 @@ export interface ActionCreator<P> {
     type: string;
     (payload: P, meta?: Object): Action<P>;
 }
+export interface EmptyActionCreator extends ActionCreator<undefined> {
+    (payload?: undefined, meta?: Object): Action<undefined>;
+}
 export interface AsyncActionCreators<P, S, E> {
     type: string;
     started: ActionCreator<P>;
@@ -25,9 +28,9 @@ export interface AsyncActionCreators<P, S, E> {
     failed: ActionCreator<Failure<P, E>>;
 }
 export interface ActionCreatorFactory {
+    (type: string, commonMeta?: Object, error?: boolean): EmptyActionCreator;
     <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
-    (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
+    async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, any>;
     async<P, S, E>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, E>;
-    async<P, S>(type: string, commonMeta?: Object, error?: boolean): AsyncActionCreators<P, S, any>;
 }
 export default function actionCreatorFactory(prefix?: string): ActionCreatorFactory;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 import { Action as ReduxAction } from "redux";
 export interface Action<P> extends ReduxAction {
     type: string;
-    payload?: P;
+    payload: P;
     error?: boolean;
     meta?: Object;
 }
 export declare function isType<P>(action: ReduxAction, actionCreator: ActionCreator<P>): action is Action<P>;
 export interface ActionCreator<P> {
     type: string;
-    (payload?: P, meta?: Object): Action<P>;
+    (payload: P, meta?: Object): Action<P>;
 }
 export interface AsyncActionCreators<P, R> {
     type: string;
@@ -24,6 +24,7 @@ export interface AsyncActionCreators<P, R> {
 }
 export interface ActionCreatorFactory {
     <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
+    (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
     async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S>;
 }
 export default function actionCreatorFactory(prefix?: string): ActionCreatorFactory;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,26 +5,29 @@ export interface Action<P> extends ReduxAction {
     error?: boolean;
     meta?: Object;
 }
+export interface Success<P, S> {
+    params: P;
+    result: S;
+}
+export interface Failure<P, E> {
+    params: P;
+    error: E;
+}
 export declare function isType<P>(action: ReduxAction, actionCreator: ActionCreator<P>): action is Action<P>;
 export interface ActionCreator<P> {
     type: string;
     (payload: P, meta?: Object): Action<P>;
 }
-export interface AsyncActionCreators<P, R> {
+export interface AsyncActionCreators<P, S, E> {
     type: string;
     started: ActionCreator<P>;
-    done: ActionCreator<{
-        params: P;
-        result: R;
-    }>;
-    failed: ActionCreator<{
-        params: P;
-        error: any;
-    }>;
+    done: ActionCreator<Success<P, S>>;
+    failed: ActionCreator<Failure<P, E>>;
 }
 export interface ActionCreatorFactory {
     <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
     (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
-    async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S>;
+    async<P, S, E>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, E>;
+    async<P, S>(type: string, commonMeta?: Object, error?: boolean): AsyncActionCreators<P, S, any>;
 }
 export default function actionCreatorFactory(prefix?: string): ActionCreatorFactory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {Action as ReduxAction} from "redux";
 
 export interface Action<P> extends ReduxAction {
   type: string;
-  payload?: P;
+  payload: P;
   error?: boolean;
   meta?: Object;
 }
@@ -17,7 +17,7 @@ export function isType<P>(
 
 export interface ActionCreator<P> {
   type: string;
-  (payload?: P, meta?: Object): Action<P>;
+  (payload: P, meta?: Object): Action<P>;
 }
 
 export interface AsyncActionCreators<P, R> {
@@ -35,6 +35,7 @@ export interface AsyncActionCreators<P, R> {
 
 export interface ActionCreatorFactory {
   <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
+  (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
 
   async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S>;
 }
@@ -54,7 +55,7 @@ ActionCreatorFactory {
     const fullType = prefix ? `${prefix}/${type}` : type;
 
     return Object.assign(
-      (payload?: P, meta?: Object) => {
+      (payload: P, meta?: Object) => {
         const action: Action<P> = {
           type: fullType,
           payload,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export interface ActionCreator<P> {
   (payload: P, meta?: Object): Action<P>;
 }
 
+export interface EmptyActionCreator extends ActionCreator<undefined> {
+  (payload?: undefined, meta?: Object): Action<undefined>;
+}
+
 export interface AsyncActionCreators<P, S, E> {
   type: string;
   started: ActionCreator<P>;
@@ -38,11 +42,11 @@ export interface AsyncActionCreators<P, S, E> {
 }
 
 export interface ActionCreatorFactory {
+  (type: string, commonMeta?: Object, error?: boolean): EmptyActionCreator;
   <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
-  (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
 
+  async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, any>;
   async<P, S, E>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, E>;
-  async<P, S>(type: string, commonMeta?: Object, error?: boolean): AsyncActionCreators<P, S, any>;
 }
 
 
@@ -89,4 +93,3 @@ ActionCreatorFactory {
 
   return Object.assign(actionCreator, {async: asyncActionCreators});
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,16 @@ export interface Action<P> extends ReduxAction {
   meta?: Object;
 }
 
+export interface Success<P, S> {
+  params: P;
+  result: S;
+}
+
+export interface Failure<P, E> {
+  params: P;
+  error: E;
+}
+
 export function isType<P>(
   action: ReduxAction,
   actionCreator: ActionCreator<P>
@@ -20,24 +30,19 @@ export interface ActionCreator<P> {
   (payload: P, meta?: Object): Action<P>;
 }
 
-export interface AsyncActionCreators<P, R> {
+export interface AsyncActionCreators<P, S, E> {
   type: string;
   started: ActionCreator<P>;
-  done: ActionCreator<{
-    params: P;
-    result: R;
-  }>;
-  failed: ActionCreator<{
-    params: P;
-    error: any;
-  }>;
+  done: ActionCreator<Success<P, S>>;
+  failed: ActionCreator<Failure<P, E>>;
 }
 
 export interface ActionCreatorFactory {
   <P>(type: string, commonMeta?: Object, error?: boolean): ActionCreator<P>;
   (type: string, commonMeta?: Object, error?: boolean): ActionCreator<undefined>;
 
-  async<P, S>(type: string, commonMeta?: Object): AsyncActionCreators<P, S>;
+  async<P, S, E>(type: string, commonMeta?: Object): AsyncActionCreators<P, S, E>;
+  async<P, S>(type: string, commonMeta?: Object, error?: boolean): AsyncActionCreators<P, S, any>;
 }
 
 
@@ -71,20 +76,14 @@ ActionCreatorFactory {
     );
   }
 
-  function asyncActionCreators<P, S>(
+  function asyncActionCreators<P, S, E>(
     type: string, commonMeta?: Object
-  ): AsyncActionCreators<P, S> {
+  ): AsyncActionCreators<P, S, E> {
     return {
       type: prefix ? `${prefix}/${type}` : type,
       started: actionCreator<P>(`${type}_STARTED`, commonMeta),
-      done: actionCreator<{
-        params: P;
-        result: S;
-      }>(`${type}_DONE`, commonMeta),
-      failed: actionCreator<{
-        params: P;
-        error: any;
-      }>(`${type}_FAILED`, commonMeta, true),
+      done: actionCreator<Success<P, S>>(`${type}_DONE`, commonMeta),
+      failed: actionCreator<Failure<P, E>>(`${type}_FAILED`, commonMeta, true),
     };
   }
 


### PR DESCRIPTION
This PR has two commits:
- Make payload non-optional my default. You can get the previous behaviour with `Action<Value | undefined>`. This is required to play well wtih `--strictNullChecks` and avoid `if (action.payload)` all over the place. Usually you want either `Action<Value>` or `Action<undefined>` anyway.
- Make the async error type a type parameter instead of `any`. We use strongly typed errors and would like to have them type checked.

We'd like to use the upstream version rather than a fork, so I'm happy to discuss alternatives if you don't agree with the changes.
